### PR TITLE
fix invalid read when copying MAC address

### DIFF
--- a/engine/src/vb_engine_datamodel.c
+++ b/engine/src/vb_engine_datamodel.c
@@ -2159,12 +2159,12 @@ t_VB_engineErrorCode VbEngineDatamodelListDomainsDMsAdd(t_VBDriver *driver, INT3
 
           // Init node Align info
           memset(&(new_domains[new_dm_idx].dm.nodeAlignInfo), 0, sizeof(new_domains[new_dm_idx].dm.nodeAlignInfo));
-        }
 
 #if VB_ENGINE_METRICS_ENABLED
-        VbMetricsReportDeviceEvent(VB_METRICS_EVENT_NEW_LINE,
-                                   new_domains[new_dm_idx].dm.MAC, TRUE, driver, 0, 0);
+          VbMetricsReportDeviceEvent(VB_METRICS_EVENT_NEW_LINE,
+                                     new_domains[new_dm_idx].dm.MAC, TRUE, driver, 0, 0);
 #endif
+        }
 
         if(driver->domainsList.domainsArray != NULL)
         {


### PR DESCRIPTION
Previously it would call function only once after for loop instead per each new added DMs. Fixes overreading memory when attempting to read MAC address.

This was found by inspecting valgrind output.