### PR TITLE
fix invalid read access in driver

### DIFF
--- a/common/vb_ea_communication.c
+++ b/common/vb_ea_communication.c
@@ -1225,7 +1225,7 @@ t_vbEAError VbEADescDestroy(t_vbEADesc *desc)
   else
   {
     // Free information used to bind and listen on socket
-    if (desc->clientInfo->ai_addr != NULL)
+    if (desc->clientInfo != NULL && desc->clientInfo->ai_addr != NULL)
     {
       freeaddrinfo(desc->clientInfo);
     }

--- a/driver/src/ExternalAgentInterface/vb_EA_interface.c
+++ b/driver/src/ExternalAgentInterface/vb_EA_interface.c
@@ -101,7 +101,7 @@
  */
 
 static t_vbEADesc      vbEAServerDesc;
-static t_vbEADesc      vbEAConnDesc;
+static t_vbEADesc      vbEAConnDesc = { 0 };
 static BOOL            vbEAServerMode;
 
 /*


### PR DESCRIPTION
This was found when debugging vector_boost_driver with valgrind on DPU.