### PR TITLE
do not attempt to call memcpy with NULL as 2nd argument

### DIFF
--- a/engine/src/ExternalAgentInterface/vb_engine_EA_interface.c
+++ b/engine/src/ExternalAgentInterface/vb_engine_EA_interface.c
@@ -551,7 +551,10 @@ t_VB_engineErrorCode VbEngineEAInterfaceSendFrame(
 
   if (result == VB_ENGINE_ERROR_NONE)
   {
-    memcpy((char *)msg->eaPayload.msg, payload, payloadLength);
+    if ((payload != NULL) && (payloadLength > 0))
+    {
+      memcpy((char *)msg->eaPayload.msg, payload, payloadLength);
+    }
 
     // Send frame
     VbEAMsgSend(&thisDriver->vbEAConnDesc, msg);


### PR DESCRIPTION
Found with valgrind when running vector_boost_engine.