### PR TITLE
Allow closing 0 socket if lcmpSc receives such number of socket

### DIFF
--- a/driver/src/LCMP/vb_LCMP_socket.c
+++ b/driver/src/LCMP/vb_LCMP_socket.c
@@ -750,7 +750,7 @@ static void LcmpReceiveThreadStop()
 
     LcmpStateSet(FALSE);
 
-    if (lcmpSc > 0)
+    if (lcmpSc >= 0)
     {
       shutdown(lcmpSc, SHUT_RDWR);
       close(lcmpSc);
@@ -1460,7 +1460,7 @@ t_VB_comErrorCode LcmpMacGet( INT8U *myMac )
 void LcmpEnd ( void )
 {
   LcmpReceiveThreadStop();
-  if(lcmpSc > 0)
+  if(lcmpSc >= 0)
   {
     close(lcmpSc);
   }


### PR DESCRIPTION
The 0 is valid socket number when returned by socket() call. Usually 0 is already taken by stdin but that may not always be the case.